### PR TITLE
FileUtils: Set Filename in Options Tab with default behaviour and customizable name

### DIFF
--- a/eloservice/elo_service.py
+++ b/eloservice/elo_service.py
@@ -1,12 +1,12 @@
 from eloclient import Client
 from eloclient.api.ix_service_port_if import (ix_service_port_if_checkin_sord_path, ix_service_port_if_delete_sord)
 from eloclient.api.ix_service_port_if import (ix_service_port_if_copy_sord)
-from eloclient.models import (BRequestIXServicePortIFCheckinSordPath, BRequestIXServicePortIFDeleteSord, SordZ, SordC)
+from eloclient.models import (BRequestIXServicePortIFCheckinSordPath, BRequestIXServicePortIFDeleteSord)
 from eloclient.models import (BRequestIXServicePortIFCopySord)
 from eloclient.models import Sord
-from eloservice.eloconstants import COPY_SORD_C_MOVE, SORD_Z_MB_ALL, SORD_Z_EMPTY
+from eloservice.eloconstants import COPY_SORD_C_MOVE, SORD_Z_EMPTY
 from eloservice.error_handler import _check_response
-from eloservice.file_util import FileUtil
+from eloservice.file_util import FileUtil, FILENAME_OBJKEY_ID_DEFAULT
 from eloservice.login_util import LoginUtil
 from eloservice.map_util import MapUtil
 from eloservice.mask_util import MaskUtil
@@ -140,29 +140,39 @@ class EloService:
         """
         self.map_util.write_map_fields(sord_id, fields, map_domain, value_type, content_type)
 
-    def upload_file(self, file_path: str, parent_id: str, filemask_id="0", filename="") -> str:
+    def upload_file(self, file_path: str, parent_id: str, filemask_id="0", filename="", filename_objkey_id=FILENAME_OBJKEY_ID_DEFAULT,
+                    filename_objkey="") -> str:
         """
         This function uploads a file to ELO
 
-        :param filename: The name of the file in ELO, if not given the name of the file_path is used
+        :param filename: The name of the file in ELO, if not given the name of the file_path is used. This is the filename
+        which is shown in the directory tree. However, also referred to as kurzbezeichnung in ELO.
         :param filemask_id:  The maskID of the filemask in ELO, default is "0" (--> mask "Freie Eingabe" = STD mask)
         :param file_path: The path of the file which should be uploaded
         :param parent_id: The sordID of the parent folder in ELO
+        :param filename_objkey_id: The objkeyID of the filename objkey in ELO, default is "51" (--> objkey "ELO_FNAME")
+        this sets the filename in the tab 'Options'
+        :filename_objkey The filename in the tab 'Options' in ELO
 
         :return: The sordID of the uploaded file
         """
         return self.file_util.upload_file(file_path=file_path, parent_id=parent_id, filemask_id=filemask_id,
-                                          filename=filename)
+                                          filename=filename, filename_objkey_id=filename_objkey_id,
+                                          filename_objkey=filename_objkey)
 
-    def update_file(self, sord_id: str, file_path: str, filename=""):
+    def update_file(self, sord_id: str, file_path: str, filename="", filename_objkey_id=FILENAME_OBJKEY_ID_DEFAULT,
+                    filename_objkey=""):
         """
         This function updates a file in ELO
 
         :param sord_id: The sordID of the file in ELO
         :param filename: The name of the file in ELO, if not given the name of the file_path is used
         :param file_path: The path of the file which should be uploaded
+        :param filename_objkey_id: The objkeyID of the filename objkey in ELO, default is "51" (--> objkey "ELO_FNAME")
+        :param filename_objkey: The filename in the tab 'Options' in ELO
         """
-        self.file_util.update_file(file_path=file_path, file_id=sord_id, filename=filename)
+        self.file_util.update_file(file_path=file_path, file_id=sord_id, filename=filename,
+                                   filename_objkey_id=filename_objkey_id, filename_objkey=filename_objkey)
 
     def search(self, search_mask_fields: dict = None, search_mask_id: str = None, max_results: int = 100) -> [str]:
         """

--- a/eloservice/file_util.py
+++ b/eloservice/file_util.py
@@ -4,7 +4,7 @@ from eloclient import Client
 from eloclient.api.ix_service_port_if import ix_service_port_if_create_doc, ix_service_port_if_checkin_doc_end, \
     ix_service_port_if_checkout_sord
 from eloclient.models import BRequestIXServicePortIFCreateDoc, Sord, BRequestIXServicePortIFCheckinDocEnd, SordZ, LockZ, \
-    LockC, Document, FileData, BStreamReference, DocVersion, BRequestIXServicePortIFCheckoutSord, EditInfoZ, EditInfoC
+    LockC, Document, FileData, BStreamReference, DocVersion, BRequestIXServicePortIFCheckoutSord, ObjKey
 from eloservice import eloconstants as elo_const
 from eloservice.error_handler import _check_response
 from eloservice.login_util import EloConnection
@@ -18,6 +18,9 @@ def _read_file(file_path):
         return file_content, file_name
 
 
+FILENAME_OBJKEY_ID_DEFAULT = "51"
+
+
 class FileUtil:
     elo_connection: EloConnection
     elo_client: Client
@@ -26,39 +29,52 @@ class FileUtil:
         self.elo_connection = elo_connection
         self.elo_client = elo_client
 
-    def update_file(self, file_path: str, file_id: str, filename="") -> str:
+    def update_file(self, file_path: str, file_id: str, filename="", filename_objkey_id=FILENAME_OBJKEY_ID_DEFAULT,
+                    filename_objkey="") -> str:
         """
         This function updates a file in ELO
         :param filename:
         :param filemask_id:  The maskID of the filemask in ELO, default is "0" (--> mask "Freie Eingabe" = STD mask)
         :param file_path: The path of the file which should be uploaded
         :param file_id: The sordID of the file which should be updated
+        :param filename_objkey_id: The objkeyID of the filename objkey in ELO, default is "51" (--> objkey "ELO_FNAME")
+        this sets the filename in the tab 'Options'
+        :param filename_objkey: This will be the filename in the tab 'Options' in ELO. If not set correctly, consider
+        setting filename_objkey_id to your specific elo instance, the ID can be found checking the objkeys db table.
         :return: The sordID of the updated file
         """
         file_content, file_name_path = _read_file(file_path)
         sord = self.checkout_sord(file_id)
-        return self._checkin_doc(sord, self.elo_connection, file_content, filename if filename else file_name_path)
+        filename_elo, kurzbezeichnung = self._prepare_checkin_doc(file_name_path, filename, filename_objkey)
+        return self._checkin_doc(sord, filecontent=file_content,
+                                 kurzbezeichnung=kurzbezeichnung, filename=filename_elo,
+                                 filename_objkey_id=filename_objkey_id)
 
-    def upload_file(self, file_path: str, parent_id: str, filemask_id="0", filename="") -> str:
+    def upload_file(self, file_path: str, parent_id: str, filemask_id="0", filename="",
+                    filename_objkey_id=FILENAME_OBJKEY_ID_DEFAULT,
+                    filename_objkey="") -> str:
         """
         This function uploads a file to ELO
-        :param filename:
+        :param filename: The name of the file in ELO, if not given the name of the file_path is used. This is the filename
+        which is shown in the directory tree. However, also referred to as kurzbezeichnung in ELO.
         :param filemask_id:  The maskID of the filemask in ELO, default is "0" (--> mask "Freie Eingabe" = STD mask)
         :param file_path: The path of the file which should be uploaded
         :param parent_id: The sordID of the parent folder in ELO
+        :param filename_objkey_id: The objkeyID of the filename objkey in ELO, default is "51" (--> objkey "ELO_FNAME")
+        this sets the filename in the tab 'Options'
+        :param filename_objkey: This will be the filename in the tab 'Options' in ELO. If not set correctly, consider
+        setting filename_objkey_id to your specific elo instance, the ID can be found checking the objkeys db table.
         :return: The sordID of the uploaded file
         """
         file_content, file_name_path = _read_file(file_path)
-        return self._checkin_new_doc(self.elo_connection, parent_id, filename if filename else file_name_path,
-                                     file_content, filemask_id)
-
-    def _checkin_new_doc(self, elo_connection, parent_id, filename, filecontent, filemask_id="0"):
+        filename_elo, kurzbezeichnung = self._prepare_checkin_doc(file_name_path, filename, filename_objkey)
         document_sord = self._create_doc(filemask_id, parent_id)
-        return self._checkin_doc(document_sord, elo_connection, filecontent, filename)
+        return self._checkin_doc(document_sord, filecontent=file_content,
+                                 kurzbezeichnung=kurzbezeichnung, filename=filename_elo,
+                                 filename_objkey_id=filename_objkey_id)
 
     def checkout_sord(self, sord_id) -> Sord:
         body = BRequestIXServicePortIFCheckoutSord(
-           
             obj_id=sord_id,
             edit_info_z=elo_const.EDIT_INFO_Z_MB_ALL,
             lock_z=LockZ(LockC().bset_no)
@@ -69,9 +85,23 @@ class FileUtil:
             raise ValueError(f"Sord with ID {sord_id} not found")
         return res.parsed.result.sord
 
-    def _checkin_doc(self, document_sord, elo_connection, filecontent, filename):
-        document_sord.name = filename
-        mimetype = mimetypes.guess_type(filename)[0]
+    def _prepare_checkin_doc(self, file_name_path, filename, filename_objkey):
+        if filename:
+            kurzbezeichnung = filename
+            filename_elo = file_name_path
+        else:
+            kurzbezeichnung = file_name_path
+            filename_elo = file_name_path
+        if filename_objkey:
+            filename_elo = filename_objkey
+        return filename_elo, kurzbezeichnung
+
+    def _checkin_doc(self, document_sord, filecontent, kurzbezeichnung, filename,
+                     filename_objkey_id=FILENAME_OBJKEY_ID_DEFAULT):
+        document_sord.name = kurzbezeichnung
+        document_sord.obj_keys = [
+            ObjKey(data=[filename], name="ELO_FNAME", id=filename_objkey_id, obj_id=document_sord.id)]
+        mimetype = mimetypes.guess_type(kurzbezeichnung)[0]
         # upload File and get the reference link
         streamID = self._upload_file(filecontent)
         document = Document(

--- a/test/test_file_util.py
+++ b/test/test_file_util.py
@@ -63,7 +63,11 @@ class TestService(unittest.TestCase):
         elo_connection, elo_client = self._login()
         util = FileUtil(elo_client, elo_connection)
         parentID = "134698"
-        sord = util.upload_file(TEST_ROOT_DIR + "/resources/testFile.png", parentID, filename="testFile.png",
+        sord = util.upload_file(TEST_ROOT_DIR + "/resources/testFile.png", parentID, filename="FileNameTestFile.png",
                                 filename_objkey="differentFilename.png")
         assert sord is not None
         assert sord != ""
+        checkSordID = sord
+        sord = util.checkout_sord(checkSordID)
+        assert sord.name == "FileNameTestFile.png"
+        assert sord.obj_keys[0].data[0] == "differentFilename.png"

--- a/test/test_file_util.py
+++ b/test/test_file_util.py
@@ -59,3 +59,11 @@ class TestService(unittest.TestCase):
         _check_not_unset(sord.guid)
         _check_not_unset(sord.obj_keys)
 
+    def test_upload_file_with_custom_filename(self):
+        elo_connection, elo_client = self._login()
+        util = FileUtil(elo_client, elo_connection)
+        parentID = "134698"
+        sord = util.upload_file(TEST_ROOT_DIR + "/resources/testFile.png", parentID, filename="testFile.png",
+                                filename_objkey="differentFilename.png")
+        assert sord is not None
+        assert sord != ""


### PR DESCRIPTION
add optional parameter filename_objkey, filename_objkey_id for upload_file and update_file. Which sets the filename in the options tab (internally done via a predefined obj_key entry)