### PR TITLE
overwrite_mask_fields add optional param metadata_force

### DIFF
--- a/eloservice/elo_service.py
+++ b/eloservice/elo_service.py
@@ -90,15 +90,18 @@ class EloService:
             raise ValueError("Could not create folder")
         return object_id
 
-    def overwrite_mask_fields(self, sord_id: str, mask_name: str, metadata: dict):
+    def overwrite_mask_fields(self, sord_id: str, mask_name: str, metadata: dict, metadata_force: dict = None):
         """
         This function removes the old metadata and overwrite it with the new metadata
 
         :param sord_id: The sordID of the mask in ELO
         :param mask_name: The name of the mask in ELO
         :param metadata: The metadata which should be overwritten
+        :param metadata_force: The metadata which should be overwritten even if the given key is not in the mask. Can be
+        needed for special metadata like the filename. The key in the dict is used as ID and as 'name' at the same time.
+        Setting the key name in ELO seems to be irrelevant anyway, the ID seems to always have priority.(default = None)
         """
-        self.mask_util.overwrite_mask_fields(sord_id, mask_name, metadata)
+        self.mask_util.overwrite_mask_fields(sord_id, mask_name, metadata, metadata_force)
 
     def write_map_fields(self, sord_id: str, fields: dict, map_domain: str = "Objekte",
                          value_type: MapUtil.ValueType = MapUtil.ValueType.string,
@@ -140,7 +143,8 @@ class EloService:
         """
         self.map_util.write_map_fields(sord_id, fields, map_domain, value_type, content_type)
 
-    def upload_file(self, file_path: str, parent_id: str, filemask_id="0", filename="", filename_objkey_id=FILENAME_OBJKEY_ID_DEFAULT,
+    def upload_file(self, file_path: str, parent_id: str, filemask_id="0", filename="",
+                    filename_objkey_id=FILENAME_OBJKEY_ID_DEFAULT,
                     filename_objkey="") -> str:
         """
         This function uploads a file to ELO

--- a/eloservice/mask_util.py
+++ b/eloservice/mask_util.py
@@ -98,8 +98,8 @@ class MaskUtil:
         _check_response(res)
         return res.parsed.result.mask
 
-    def overwrite_mask_fields(self, sord_id: str, mask_name: str, metadata: dict):
-        sord = self.create_local_sord(mask_name, metadata, sord_id)
+    def overwrite_mask_fields(self, sord_id: str, mask_name: str, metadata: dict, metadata_force: dict = None):
+        sord = self._create_local_sord(mask_name, metadata, sord_id, metadata_force)
         body = BRequestIXServicePortIFCheckinSord(
             sord=sord,
             sord_z=SordZ_INFO_MB_MASK_INFOS,
@@ -108,7 +108,7 @@ class MaskUtil:
         erg = ix_service_port_if_checkin_sord.sync_detailed(client=self.elo_client, body=body)
         _check_response(erg)
 
-    def create_local_sord(self, mask_name, metadata, sord_id):
+    def _create_local_sord(self, mask_name, metadata, sord_id, metadata_force=None):
         mask = self.get_mask_name(mask_name)
         if mask is None:
             raise ValueError(f"Mask '{mask_name}' not found in ELO")
@@ -126,6 +126,12 @@ class MaskUtil:
                                             id=key_id))
             except ValueError:
                 logging.warning(f"Could not find key '{key}' in mask '{mask.name}', ignoring property and continuing")
+
+        if metadata_force is not None:
+            for key, value in metadata_force.items():
+                sord.obj_keys.append(ObjKey(data=[value], obj_id=sord_id, name=key,
+                                            id=key))
+
         return sord
 
     def get_mask_name(self, mask_name):

--- a/test/test_mask_util.py
+++ b/test/test_mask_util.py
@@ -40,3 +40,20 @@ class TestService(unittest.TestCase):
                 "ITEMDOCDATE": "2023-12-26"
             }
         )
+
+    def test_set_force_metadata_on_sord(self):
+        #path in elo: ¶EIWECK_INTEGRATION_TEST¶PythonAPI¶test_mask_api¶test_set_force_metadata_on_sord
+        elo_connection, elo_client = self._login()
+        util = MaskUtil(elo_client, elo_connection)
+        erg = util.overwrite_mask_fields(
+            sord_id="140523",
+            mask_name="Images",
+            metadata={
+                "LATITUDE": "35.732554",
+                "LONGITUDE": "139.714302",
+                "ITEMDOCDATE": "2023-12-26"
+            },
+            metadata_force={
+                "51": "testCustoMFilename.png"
+            }
+        )


### PR DESCRIPTION
Add metadata_force to method overwrite_mask_fields. This allows to set metadata by ID that is otherwise not assignable to a mask. Useful in certain cases like the special filename mask objkeys