### PR TITLE
uploadFile updateFile: automatically set x_date_iso and add optional …

### DIFF
--- a/eloservice/elo_service.py
+++ b/eloservice/elo_service.py
@@ -148,7 +148,7 @@ class EloService:
     def upload_file(self, file_path: str, parent_id: str, filemask_id="0", filename="",
                     filename_objkey_id=FILENAME_OBJKEY_ID_DEFAULT,
                     filename_objkey="",
-                    filedate=datetime.now().isoformat()) -> str:
+                    filedate=None) -> str:
         """
         This function uploads a file to ELO
 
@@ -171,7 +171,7 @@ class EloService:
 
     def update_file(self, sord_id: str, file_path: str, filename="", filename_objkey_id=FILENAME_OBJKEY_ID_DEFAULT,
                     filename_objkey="",
-                    filedate=datetime.now().isoformat()):
+                    filedate=None):
         """
         This function updates a file in ELO
 

--- a/eloservice/elo_service.py
+++ b/eloservice/elo_service.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from eloclient import Client
 from eloclient.api.ix_service_port_if import (ix_service_port_if_checkin_sord_path, ix_service_port_if_delete_sord)
 from eloclient.api.ix_service_port_if import (ix_service_port_if_copy_sord)
@@ -145,7 +147,8 @@ class EloService:
 
     def upload_file(self, file_path: str, parent_id: str, filemask_id="0", filename="",
                     filename_objkey_id=FILENAME_OBJKEY_ID_DEFAULT,
-                    filename_objkey="") -> str:
+                    filename_objkey="",
+                    filedate=datetime.now().isoformat()) -> str:
         """
         This function uploads a file to ELO
 
@@ -156,16 +159,19 @@ class EloService:
         :param parent_id: The sordID of the parent folder in ELO
         :param filename_objkey_id: The objkeyID of the filename objkey in ELO, default is "51" (--> objkey "ELO_FNAME")
         this sets the filename in the tab 'Options'
-        :filename_objkey The filename in the tab 'Options' in ELO
-
+        :param filename_objkey The filename in the tab 'Options' in ELO
+        :param filedate: The date of the file, default is the modification date of the file. Format is in ISO 8601 e.g.
+        "2021-08-25T15:00:00"
         :return: The sordID of the uploaded file
         """
         return self.file_util.upload_file(file_path=file_path, parent_id=parent_id, filemask_id=filemask_id,
                                           filename=filename, filename_objkey_id=filename_objkey_id,
-                                          filename_objkey=filename_objkey)
+                                          filename_objkey=filename_objkey,
+                                          filedate=filedate)
 
     def update_file(self, sord_id: str, file_path: str, filename="", filename_objkey_id=FILENAME_OBJKEY_ID_DEFAULT,
-                    filename_objkey=""):
+                    filename_objkey="",
+                    filedate=datetime.now().isoformat()):
         """
         This function updates a file in ELO
 
@@ -174,9 +180,12 @@ class EloService:
         :param file_path: The path of the file which should be uploaded
         :param filename_objkey_id: The objkeyID of the filename objkey in ELO, default is "51" (--> objkey "ELO_FNAME")
         :param filename_objkey: The filename in the tab 'Options' in ELO
+        :param filedate: The date of the file, default is the modification date of the file. Format is in ISO 8601 e.g.
+        "2021-08-25T15:00:00"
         """
         self.file_util.update_file(file_path=file_path, file_id=sord_id, filename=filename,
-                                   filename_objkey_id=filename_objkey_id, filename_objkey=filename_objkey)
+                                   filename_objkey_id=filename_objkey_id, filename_objkey=filename_objkey,
+                                   filedate=filedate)
 
     def search(self, search_mask_fields: dict = None, search_mask_id: str = None, max_results: int = 100) -> [str]:
         """

--- a/eloservice/elo_service.py
+++ b/eloservice/elo_service.py
@@ -1,5 +1,3 @@
-from datetime import datetime
-
 from eloclient import Client
 from eloclient.api.ix_service_port_if import (ix_service_port_if_checkin_sord_path, ix_service_port_if_delete_sord)
 from eloclient.api.ix_service_port_if import (ix_service_port_if_copy_sord)
@@ -160,8 +158,9 @@ class EloService:
         :param filename_objkey_id: The objkeyID of the filename objkey in ELO, default is "51" (--> objkey "ELO_FNAME")
         this sets the filename in the tab 'Options'
         :param filename_objkey The filename in the tab 'Options' in ELO
-        :param filedate: The date of the file, default is the modification date of the file. Format is in ISO 8601 e.g.
-        "2021-08-25T15:00:00"
+        :param filedate: The date of the file, in UTC, default is the modification date of the file. Format is in
+        ISO 8601 e.g."2021-08-25T15:00:00". The date is stored in UTC in ELO and displayed in the local time zone of the
+         user client.
         :return: The sordID of the uploaded file
         """
         return self.file_util.upload_file(file_path=file_path, parent_id=parent_id, filemask_id=filemask_id,
@@ -180,8 +179,9 @@ class EloService:
         :param file_path: The path of the file which should be uploaded
         :param filename_objkey_id: The objkeyID of the filename objkey in ELO, default is "51" (--> objkey "ELO_FNAME")
         :param filename_objkey: The filename in the tab 'Options' in ELO
-        :param filedate: The date of the file, default is the modification date of the file. Format is in ISO 8601 e.g.
-        "2021-08-25T15:00:00"
+        :param filedate: The date of the file, in UTC, default is the modification date of the file. Format is in
+        ISO 8601 e.g."2021-08-25T15:00:00". The date is stored in UTC in ELO and displayed in the local time zone of the
+         user client.
         """
         self.file_util.update_file(file_path=file_path, file_id=sord_id, filename=filename,
                                    filename_objkey_id=filename_objkey_id, filename_objkey=filename_objkey,

--- a/eloservice/file_util.py
+++ b/eloservice/file_util.py
@@ -33,7 +33,7 @@ class FileUtil:
 
     def update_file(self, file_path: str, file_id: str, filename="", filename_objkey_id=FILENAME_OBJKEY_ID_DEFAULT,
                     filename_objkey="",
-                    filedate=datetime.now().isoformat()) -> str:
+                    filedate=None) -> str:
         """
         This function updates a file in ELO
         :param filedate: The date of the file, default is the modification date of the file. Format is in ISO 8601 e.g.
@@ -61,7 +61,7 @@ class FileUtil:
     def upload_file(self, file_path: str, parent_id: str, filemask_id="0", filename="",
                     filename_objkey_id=FILENAME_OBJKEY_ID_DEFAULT,
                     filename_objkey="",
-                    filedate=datetime.now().isoformat()) -> str:
+                    filedate=None) -> str:
         """
         This function uploads a file to ELO
         :param filedate: The date of the file, default is the modification date of the file. Format is in ISO 8601 e.g.

--- a/eloservice/file_util.py
+++ b/eloservice/file_util.py
@@ -1,6 +1,6 @@
 import mimetypes
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 
 from eloclient import Client
 from eloclient.api.ix_service_port_if import ix_service_port_if_create_doc, ix_service_port_if_checkin_doc_end, \
@@ -10,15 +10,6 @@ from eloclient.models import BRequestIXServicePortIFCreateDoc, Sord, BRequestIXS
 from eloservice import eloconstants as elo_const
 from eloservice.error_handler import _check_response
 from eloservice.login_util import EloConnection
-
-
-def _read_file(file_path):
-    # read file as binary and return it together with the file name
-    with open(file_path, "rb") as file:
-        file_content = file.read()
-        file_name = file.name[file.name.rfind("/") + 1:]
-        return file_content, file_name
-
 
 FILENAME_OBJKEY_ID_DEFAULT = "51"
 
@@ -36,9 +27,10 @@ class FileUtil:
                     filedate=None) -> str:
         """
         This function updates a file in ELO
-        :param filedate: The date of the file, default is the modification date of the file. Format is in ISO 8601 e.g.
-        "2021-08-25T15:00:00"
-        :param filename:
+        :param filename: The name of the file in ELO, if not given the name of the file_path is used. This is the filename
+        which is shown in the directory tree. However, also referred to as kurzbezeichnung in ELO.
+        :param filedate: The date of the file, in UTC, default is the modification date of the file. Format is in ISO 8601 e.g.
+        "2021-08-25T15:00:00".
         :param filemask_id:  The maskID of the filemask in ELO, default is "0" (--> mask "Freie Eingabe" = STD mask)
         :param file_path: The path of the file which should be uploaded
         :param file_id: The sordID of the file which should be updated
@@ -48,9 +40,8 @@ class FileUtil:
         setting filename_objkey_id to your specific elo instance, the ID can be found checking the objkeys db table.
         :return: The sordID of the updated file
         """
-        file_content, file_name_path = _read_file(file_path)
-        filedate = datetime.fromtimestamp(
-            os.path.getmtime(file_path)).isoformat() if filedate is None else filedate
+        file_content, file_name_path = self._read_file(file_path)
+        filedate = self._getfiledate(file_path, filedate)
         sord = self.checkout_sord(file_id)
         filename_elo, kurzbezeichnung = self._prepare_checkin_doc(file_name_path, filename, filename_objkey)
         return self._checkin_doc(sord, filecontent=file_content,
@@ -64,10 +55,10 @@ class FileUtil:
                     filedate=None) -> str:
         """
         This function uploads a file to ELO
-        :param filedate: The date of the file, default is the modification date of the file. Format is in ISO 8601 e.g.
-        "2021-08-25T15:00:00"
         :param filename: The name of the file in ELO, if not given the name of the file_path is used. This is the filename
         which is shown in the directory tree. However, also referred to as kurzbezeichnung in ELO.
+        :param filedate: The date of the file, in UTC, default is the modification date of the file. Format is in ISO 8601 e.g.
+        "2021-08-25T15:00:00".
         :param filemask_id:  The maskID of the filemask in ELO, default is "0" (--> mask "Freie Eingabe" = STD mask)
         :param file_path: The path of the file which should be uploaded
         :param parent_id: The sordID of the parent folder in ELO
@@ -77,9 +68,8 @@ class FileUtil:
         setting filename_objkey_id to your specific elo instance, the ID can be found checking the objkeys db table.
         :return: The sordID of the uploaded file
         """
-        file_content, file_name_path = _read_file(file_path)
-        filedate = datetime.fromtimestamp(
-            os.path.getmtime(file_path)).isoformat() if filedate is None else filedate
+        file_content, file_name_path = self._read_file(file_path)
+        filedate = self._getfiledate(file_path, filedate)
         filename_elo, kurzbezeichnung = self._prepare_checkin_doc(file_name_path, filename, filename_objkey)
         document_sord = self._create_doc(filemask_id, parent_id)
         return self._checkin_doc(document_sord, filecontent=file_content,
@@ -98,6 +88,46 @@ class FileUtil:
         if type(res.parsed.result.sord) is not Sord:
             raise ValueError(f"Sord with ID {sord_id} not found")
         return res.parsed.result.sord
+
+    def _read_file(self, file_path):
+        try:
+            # read file as binary and return it together with the file name
+            with open(file_path, "rb") as file:
+                file_content = file.read()
+                file_name = file.name[file.name.rfind("/") + 1:]
+                return file_content, file_name
+        except FileNotFoundError:
+            raise FileNotFoundError(f"File {file_path} not found")
+        except Exception as e:
+            raise ValueError(f"Error while reading file {file_path}: {e}")
+
+    def _getfiledate(self, file_path, filedate):
+        """
+        This function returns the filedate of a file. If filedate is given, it will be returned, otherwise the
+        modification date of the file will be returned.
+        :param file_path:
+        :param filedate:
+        :return:
+        """
+        if filedate:
+            try:
+                datetime.fromisoformat(filedate)
+            except ValueError:
+                raise ValueError("The filedate is not in the correct format. Please use ISO 8601 format e.g. "
+                                 "2021-08-25T15:00:00")
+            return filedate
+
+        modified_filedate = datetime.fromtimestamp(os.path.getmtime(file_path))
+
+        # get the time difference between the local time and UTC; WE read the filedate 'now' therefore we need to use
+        # this difference to convert the filedate to UTC. And not the offset of the filedate itself.
+        # e.g if the file was created in wintertime and we read it in summertime, the offset would be wrong.
+        tzinfo = datetime.now(timezone.utc).astimezone().tzinfo
+        time_difference = tzinfo.utcoffset(datetime.now())
+
+        # subtract the time difference to the modified file date so we get UTC time
+        modified_filedate = modified_filedate - time_difference
+        return modified_filedate.isoformat()
 
     def _prepare_checkin_doc(self, file_name_path, filename, filename_objkey):
         if filename:

--- a/test/test_file_util.py
+++ b/test/test_file_util.py
@@ -71,3 +71,18 @@ class TestService(unittest.TestCase):
         sord = util.checkout_sord(checkSordID)
         assert sord.name == "importantDokument"
         assert sord.obj_keys[0].data[0] == "chicken.pdf"
+
+    def test_upload_file_with_custom_filedate(self):
+        elo_connection, elo_client = self._login()
+        util = FileUtil(elo_client, elo_connection)
+        parentID = "134698"
+        sord = util.upload_file(TEST_ROOT_DIR + "/resources/chicken.pdf", parentID, filename="customFiledate",
+                                filename_objkey="chicken.pdf",
+                                filedate="2021-08-25T15:00:00")
+        assert sord is not None
+        assert sord != ""
+        checkSordID = sord
+        sord = util.checkout_sord(checkSordID)
+        assert sord.name == "customFiledate"
+        assert sord.x_date_iso == "20210825150000"
+        assert sord.obj_keys[0].data[0] == "chicken.pdf"


### PR DESCRIPTION
the objidate is already set via the python lib.

 

Per default, a SORD in ELO can have an internal and external date.

Internal = Sord.objidate = Time of the archiving

External = Sord.objxdate = Primary document date (optional)

The document date is usually set by the client and the Java Client sets it today, if the user is not overwriting it. The document date is an important aspect, while using the search filters.

In the long run, it makes sense to set it by the API consumer. 