### PR TITLE
add method get_mask_fields

### DIFF
--- a/eloservice/elo_service.py
+++ b/eloservice/elo_service.py
@@ -238,6 +238,26 @@ class EloService:
         """
         return self.file_util.checkout_sord(sord_id)
 
+    def get_mask_fields(self, sord_id: str) -> dict:
+        """
+        This function returns the mask fields of a sord in ELO
+
+        ELOFIELD -> Python type:
+
+        * text -> str
+
+        * numerical -> float, int, Decimal
+
+        * date(time) -> datetime
+
+        * list -> list of str
+
+        :param sord_id: The sordID of the sord in ELO
+        :return: The mask fields of the sord
+        """
+        return self.mask_util.get_mask_fields(sord_id)
+
+
     def remove(self, sord_id: str):
         """
         This function removes a sord in ELO

--- a/eloservice/eloconstants.py
+++ b/eloservice/eloconstants.py
@@ -1,6 +1,6 @@
 from enum import Enum
 
-from eloclient.models import SordZ, SordC, EditInfoZ, EditInfoC, copy_sord_z, CopySordC, LockC
+from eloclient.models import SordZ, SordC, EditInfoZ, EditInfoC, copy_sord_z, CopySordC, LockC, LockZ
 
 
 class ElobitsetEditz(Enum):
@@ -37,5 +37,7 @@ EDIT_INFO_Z_MB_MASK_INFOS.sord_z.bset = str(int(ElobitsetEditz.MB_OBJ_KEYS.value
 
 SordZ_INFO_MB_MASK_INFOS = SordZ(bset=EDIT_INFO_Z_MB_MASK_INFOS.bset)
 
-LOCK_Z_YES = SordZ(LockC().yes)
-LOCK_Z_NO = SordZ(LockC().no)
+LOCK_Z_YES = LockZ("1")
+LOCK_Z_NO = LockZ("0")
+LOCK_Z_IF_FREE = LockZ("2")
+LOCK_Z_FORCE = LockZ("4")

--- a/eloservice/mask_util.py
+++ b/eloservice/mask_util.py
@@ -1,10 +1,14 @@
 import logging
+from datetime import datetime
+
 import cachetools
+from decimal import Decimal
 
 from eloclient import Client
 from eloclient.api.ix_service_port_if import ix_service_port_if_create_sord, \
-    ix_service_port_if_checkin_sord
-from eloclient.models import BRequestIXServicePortIFCheckinSord, BRequestIXServicePortIFCreateSord
+    ix_service_port_if_checkin_sord, ix_service_port_if_checkout_sord
+from eloclient.models import BRequestIXServicePortIFCheckinSord, BRequestIXServicePortIFCreateSord, \
+    BRequestIXServicePortIFCheckoutSord, LockZ, LockC
 from eloclient.models import MaskName, DocMask, Sord, ObjKey
 from eloservice import eloconstants as elo_const
 from eloservice.eloconstants import SordZ_INFO_MB_MASK_INFOS, LOCK_Z_NO
@@ -137,3 +141,247 @@ class MaskUtil:
         masks: [MaskName] = self.get_all_masks_names()
         mask: MaskName = next((m for m in masks if m.name == mask_name), None)
         return mask
+
+    def get_mask_fields(self, sord_id) -> dict:
+        """
+        Get all fields for a certain sord_id. The values are casted according to the configured mask line types.
+        :param sord_id:
+        :return:
+        """
+        body = BRequestIXServicePortIFCheckoutSord(
+            obj_id=sord_id,
+            edit_info_z=elo_const.EDIT_INFO_Z_MB_ALL,
+            lock_z=LOCK_Z_NO
+        )
+        res = ix_service_port_if_checkout_sord.sync_detailed(client=self.elo_client, body=body)
+        _check_response(res)
+        if type(res.parsed.result.sord) is not Sord:
+            raise ValueError(f"Sord with ID {sord_id} not found")
+        sord:Sord = res.parsed.result.sord
+        doc_mask:DocMask = self.get_mask_detail(sord.mask)
+        erg = {obj_key.name: self._cast_obj_key(obj_key, doc_mask) for obj_key in sord.obj_keys}
+        return erg
+
+    def _get_mask_field_type(self,obj_key:ObjKey, doc_mask:DocMask) -> str:
+        for line in doc_mask.lines:
+            if line.key == obj_key.name:
+                 return self._translate_obj_type_nr_to_str(line.type)
+        logging.warning(f"Could not find key '{obj_key.name}' in mask '{doc_mask.name}'")
+        return "Not implemented"
+
+    def _cast_obj_key(self, obj_key:ObjKey, doc_mask:DocMask):
+        if len(obj_key.data) == 0:
+            return None
+        obj_type = self._get_mask_field_type(obj_key, doc_mask)
+        if obj_type == "TYPE_TEXT":
+            return obj_key.data[0]
+        elif obj_type == "TYPE_DATE":
+            return self._parse_date(obj_key)
+        elif obj_type == "TYPE_NUMBER":
+            return Decimal(obj_key.data[0])
+        elif obj_type == "TYPE_AZ":
+            return obj_key.data[0]
+        elif obj_type == "TYPE_ISO_DATE":
+            return self._parse_date(obj_key)
+        elif obj_type == "TYPE_LIST":
+            return obj_key.data
+        elif obj_type == "TYPE_USER":
+            # todo idk, maybe userID ?
+            return obj_key.data[0]
+        elif obj_type == "TYPE_THES":
+            # todo
+            return obj_key.data[0]
+        elif obj_type == "TYPE_NUMBER_F0":
+            return Decimal(obj_key.data[0])
+        elif obj_type == "TYPE_NUMBER_F1":
+            return Decimal(obj_key.data[0])
+        elif obj_type == "TYPE_NUMBER_F2":
+            return Decimal(obj_key.data[0])
+        elif obj_type == "TYPE_NUMBER_F4":
+            return Decimal(obj_key.data[0])
+        elif obj_type == "TYPE_NUMBER_F6":
+            return Decimal(obj_key.data[0])
+        elif obj_type == "TYPE_INTEGER":
+            return Decimal(obj_key.data[0])
+        elif obj_type == "TYPE_LONG":
+            return Decimal(obj_key.data[0])
+        elif obj_type == "TYPE_FLOAT":
+            return float(obj_key.data[0])
+        elif obj_type == "TYPE_DOUBLE":
+            return float(obj_key.data[0])
+        elif obj_type == "TYPE_DUMMY":
+            return obj_key.data[0]
+        elif obj_type == "TYPE_RELATION":
+            return obj_key.data[0]
+        else:
+            logging.warning(f"Could not find type number '{obj_type}'")
+            return obj_key.data[0]
+
+    def _parse_date(self, obj_key):
+        try:  # yyyyMMddHHmmss
+            return datetime.strptime(obj_key.data[0], "%Y%m%d%H%M%S")
+        except ValueError:
+            pass
+        try:  # yyyyMMdd
+            return datetime.strptime(obj_key.data[0], "%Y%m%d")
+        except ValueError:
+            pass
+        try:  # yyyy-MM-dd HH:mm:ss
+            return datetime.strptime(obj_key.data[0], "%Y-%m-%d %H:%M:%S")
+        except ValueError:
+            pass
+        try:  # yyyy-MM-dd
+            return datetime.strptime(obj_key.data[0], "%Y-%m-%d")
+        except ValueError:
+            pass
+        try:  # yyyy-MM-ddTHH:mm:ss
+            return datetime.strptime(obj_key.data[0], "%Y-%m-%dT%H:%M:%S")
+        except ValueError:
+            pass
+        logging.warning(f"Could not parse date '{obj_key.data[0]}'")
+        return obj_key.data[0]
+
+    def _translate_obj_type_nr_to_str(self, nr:int) -> str:
+        """
+          /**
+   * Used to check wether a correct constant is used.
+   */
+  public static final int _TYPE_TYPE_ID = 3000;
+  /**
+   * Index line contains text information.
+   */
+  public static final int TYPE_TEXT = _TYPE_TYPE_ID + 0;
+  /**
+   * Index line contains a date.
+   */
+  public static final int TYPE_DATE = _TYPE_TYPE_ID + 1;
+  /**
+   * Index line contains a number. The number is internally stored as a string
+   * value without any padding. Thus it is not possible to search over an interval.
+   * Use one of the TYPE_NUMBER_F* types to be able to search over intervals.
+   * The number must be formatted according to the locale information of the server.
+   * @see #TYPE_NUMBER_F0 TYPE_NUMBER_F0
+   */
+  public static final int TYPE_NUMBER = _TYPE_TYPE_ID + 2;
+  /**
+   * Index line contains a reference number ("Aktenzeichen").
+   */
+  public static final int TYPE_AZ = _TYPE_TYPE_ID + 3;
+  /**
+   * Index line contains a date in ISO format.
+   */
+  public static final int TYPE_ISO_DATE = _TYPE_TYPE_ID + 4;
+  /**
+   * Index line contains a list entry.
+   */
+  public static final int TYPE_LIST = _TYPE_TYPE_ID + 5;
+  /**
+   * Index line contains a user name.
+   */
+  public static final int TYPE_USER = _TYPE_TYPE_ID + 6;
+  /**
+   * Thesaurus
+   */
+  public static final int TYPE_THES = _TYPE_TYPE_ID + 7;
+  /**
+   * Index line contains a number value with an arbitrary number of fraction digits.
+   * The value is internally stored with a padding of &amp; (positive numbers)
+   * or @ (negative numbers). This gives the possibility to search over an interval
+   * of numeric values, e. b. search for "1 ... 12" finds objects with index values 1,2,3,4,...12.
+   * The number must be formatted according to the locale information given in the ClientInfo object.
+   * With this type, the user is responsible to enter always the same number of fraction digits.
+   * Otherwise, a search over a number range will not return the correct results.
+   * The meaning of this field was changed in 8.00.032. The meaning before was a field without any fraction digits.
+   * @see #TYPE_NUMBER TYPE_NUMBER
+   */
+  public static final int TYPE_NUMBER_F0 = _TYPE_TYPE_ID + 8;
+  /**
+   * Index line contains a number value with one digit after the decimal point.
+   * @see #TYPE_NUMBER_F0 TYPE_NUMBER_F0
+   */
+  public static final int TYPE_NUMBER_F1 = _TYPE_TYPE_ID + 9;
+  /**
+   * Index line contains a number value with one digit after the decimal point.
+   * @see #TYPE_NUMBER_F0 TYPE_NUMBER_F0
+   */
+  public static final int TYPE_NUMBER_F2 = _TYPE_TYPE_ID + 10;
+  /**
+   * Index line contains a number value of with four digits after the decimal point.
+   * @see #TYPE_NUMBER_F0 TYPE_NUMBER_F0
+   */
+  public static final int TYPE_NUMBER_F4 = _TYPE_TYPE_ID + 11;
+  /**
+   * Index line contains a number value with six digits after the decimal point.
+   * @see #TYPE_NUMBER_F0 TYPE_NUMBER_F0
+   */
+  public static final int TYPE_NUMBER_F6 = _TYPE_TYPE_ID + 12;
+  /**
+   * Index line contains a number value without fraction in the range of (-2^31) to (2^31)-1.
+   * This type can only be used for keywording forms with {@link DocMaskC#DATA_ORGANISATION_TABLE}.
+   * @since 9.00.039.001
+   */
+  public static final int TYPE_INTEGER = _TYPE_TYPE_ID + 13;
+  /**
+   * Index line contains a number value without fraction in the range of (-2^63) to (2^63)-1.
+   * This type can only be used for keywording forms with {@link DocMaskC#DATA_ORGANISATION_TABLE}.
+   * @since 9.00.039.001
+   */
+  public static final int TYPE_LONG = _TYPE_TYPE_ID + 14;
+  /**
+   * Index line contains a floating point number value with 7 significant digits.
+   * This type can only be used for keywording forms with {@link DocMaskC#DATA_ORGANISATION_TABLE}.
+   * To assign a value of this type to {@link ObjKey#data}, the String representation has to conform to the Float.toString() method of Java.
+   * Use dot to separate the fraction part and character 'E' to prefix the exponent.
+   * @since 9.00.039.001
+   */
+  public static final int TYPE_FLOAT = _TYPE_TYPE_ID + 15;
+  /**
+   * Index line contains a floating point number value with 15 significant digits.
+   * This type can only be used for keywording forms with {@link DocMaskC#DATA_ORGANISATION_TABLE}.
+   * To assign a value of this type to {@link ObjKey#data}, the String representation has to conform to the Double.toString() method of Java.
+   * Use dot to separate the fraction part and character 'E' to prefix the exponent.
+   * @since 9.00.039.001
+   */
+  public static final int TYPE_DOUBLE = _TYPE_TYPE_ID + 16;
+
+  /**
+   * Index line contains a dummy entry which should not be displayed.
+   * @since 12.00.000.001
+   */
+  public static final int TYPE_DUMMY = _TYPE_TYPE_ID + 17;
+
+  /**
+   * Index line contains a relation.
+   * A Relation consists of a {@link Sord#guid} which references a {@link Sord}.
+   * with a allowed DocMask {@link DocMaskDetails#keywordingRelationAllowed}.
+   * @since 12.00.000.023
+   */
+  public static final int TYPE_RELATION = _TYPE_TYPE_ID + 18;
+  // EIX-920, EIX-918 Relationen in der Verschlagwortung
+        """
+        mapping = {
+            3000: "TYPE_TEXT",
+            3001: "TYPE_DATE",
+            3002: "TYPE_NUMBER",
+            3003: "TYPE_AZ",
+            3004: "TYPE_ISO_DATE",
+            3005: "TYPE_LIST",
+            3006: "TYPE_USER",
+            3007: "TYPE_THES",
+            3008: "TYPE_NUMBER_F0",
+            3009: "TYPE_NUMBER_F1",
+            3010: "TYPE_NUMBER_F2",
+            3011: "TYPE_NUMBER_F4",
+            3012: "TYPE_NUMBER_F6",
+            3013: "TYPE_INTEGER",
+            3014: "TYPE_LONG",
+            3015: "TYPE_FLOAT",
+            3016: "TYPE_DOUBLE",
+            3017: "TYPE_DUMMY",
+            3018: "TYPE_RELATION"
+        }
+        res = mapping.get(nr)
+        if res is None:
+            raise ValueError(f"Could not find type number '{nr}'")
+        return res
+

--- a/test/test_mask_util.py
+++ b/test/test_mask_util.py
@@ -1,4 +1,6 @@
 import unittest
+from datetime import datetime
+
 from eloservice.login_util import LoginUtil
 from eloservice.mask_util import MaskUtil
 import os
@@ -42,7 +44,7 @@ class TestService(unittest.TestCase):
         )
 
     def test_set_force_metadata_on_sord(self):
-        #path in elo: ¶EIWECK_INTEGRATION_TEST¶PythonAPI¶test_mask_api¶test_set_force_metadata_on_sord
+        #path in elo: ¶EIWECK_INTEGRATION_TEST¶PythonAPI¶test_mask_api¶test_set_metadata_on_sord
         elo_connection, elo_client = self._login()
         util = MaskUtil(elo_client, elo_connection)
         erg = util.overwrite_mask_fields(
@@ -57,3 +59,15 @@ class TestService(unittest.TestCase):
                 "51": "testCustoMFilename.png"
             }
         )
+
+    def test_get_mask_fields(self):
+        #path in elo: ¶EIWECK_INTEGRATION_TEST¶PythonAPI¶test_mask_api¶test_get_mask_fields
+        elo_connection, elo_client = self._login()
+        util = MaskUtil(elo_client, elo_connection)
+        mask_fields = util.get_mask_fields(sord_id="139942")
+        assert mask_fields is not None
+        assert len(mask_fields) > 0
+        assert mask_fields['LATITUDE'] == "35.732554"
+        assert mask_fields['LONGITUDE'] == "139.714302"
+        assert mask_fields['ITEMDOCDATE'] == datetime.strptime("2023-12-26", "%Y-%m-%d")
+        assert mask_fields['ITEMNAME'] is None


### PR DESCRIPTION
* add a convient method to automatically convert the obj_keys from a sord to a dict and cast them to their type according to the config in the docmask. 