### PR TITLE
Add helper serializer methods to transform from/to the keyValue Elo Table Format to a default python list[dict]

### DIFF
--- a/eloservice/elo_service.py
+++ b/eloservice/elo_service.py
@@ -156,12 +156,14 @@ class EloService:
         """
         return self.map_util.read_map_fields(sord_id=sord_id, keys=keys, map_domain=map_domain)
 
-    def transform_keyvalue_to_table(self, map_fields: dict[str, MapUtil.MapValue], table_name: str,
-                                    column_names: list[str]):
+    def serialize_map_fields_table(self, map_fields: dict[str, MapUtil.MapValue], table_name: str,
+                                   column_names: list[str]):
         """
-        Helper Method to transform the result of read_map_fields to a table like datastructure
+        Helper Method to serializes, given the raw elo map fields, a table like format. The table is represented as a list
+        of dictionaries, where each dictionary represents a row in the table.
+        All operations are done in memory and no ELO operations are performed.
 
-        In Elo a table is faked by formatting the keys of the map fields. Example:
+        In Elo a table inside the map fields, is faked by formatting the keys of the map fields. Example:
         table_name is "EMPLOYEE" and columns are "NAME", "AGE", and we assume 2 rows, then the keys are formatted
         as follows:
         "EMPLOYEE_NAME1", "EMPLOYEE_AGE1", "EMPLOYEE_NAME2", "EMPLOYEE_AGE2"
@@ -174,11 +176,14 @@ class EloService:
         :param column_names: a list of column names
         :return: a list of dictionaries, each dictionary represents a row in the table
         """
-        return self.map_util.transform_keyvalue_to_table(map_fields, table_name, column_names)
+        return self.map_util.serialize_table(map_fields, table_name, column_names)
 
-    def transform_table_to_keyvalue(self, table: list[dict[str, MapUtil.MapValue]], table_name: str) -> dict[str, str]:
+    def deserialize_map_fields_table(self, table: list[dict[str, MapUtil.MapValue]], table_name: str) -> dict[str, str]:
         """
-        Helper Method to transform a table like datastructure to a dictionary of map fields
+        The reverse of serialize_map_fields_table.
+        Given a table, it transforms it to a dictionary of map fields.
+        Which can be directly written to elo via the method write_map_fields.
+        All operations are done in memory and no ELO operations are performed.
 
         In Elo a table is faked by formatting the keys of the map fields. Example:
         table_name is "EMPLOYEE" and columns are "NAME", "AGE", and we assume 2 rows, then the keys are formatted
@@ -194,7 +199,7 @@ class EloService:
         :param table_name: the name of the table
         :return: a dictionary of map fields
         """
-        return self.map_util.transform_table_to_keyvalue(table, table_name)
+        return self.map_util.deserialize_table(table, table_name)
 
     def upload_file(self, file_path: str, parent_id: str, filemask_id="0", filename="",
                     filename_objkey_id=FILENAME_OBJKEY_ID_DEFAULT,

--- a/eloservice/elo_service.py
+++ b/eloservice/elo_service.py
@@ -143,7 +143,8 @@ class EloService:
         """
         self.map_util.write_map_fields(sord_id, fields, map_domain, value_type, content_type)
 
-    def read_map_fields(self, sord_id: str, keys: list[str] = None, map_domain: str = "Objekte") -> dict[str, MapUtil.MapValue]:
+    def read_map_fields(self, sord_id: str, keys: list[str] = None, map_domain: str = "Objekte") -> dict[
+        str, MapUtil.MapValue]:
         """
         This function read either all map fields or a list of specific map field from a sord in ELO. In both cases, the
         return type is a dictionary with the key as the key of the map field and the value as the value of the map field.
@@ -154,6 +155,46 @@ class EloService:
             the additional infos tab. Common map domains are 'Objekte' and 'Formdata'.
         """
         return self.map_util.read_map_fields(sord_id=sord_id, keys=keys, map_domain=map_domain)
+
+    def transform_keyvalue_to_table(self, map_fields: dict[str, MapUtil.MapValue], table_name: str,
+                                    column_names: list[str]):
+        """
+        Helper Method to transform the result of read_map_fields to a table like datastructure
+
+        In Elo a table is faked by formatting the keys of the map fields. Example:
+        table_name is "EMPLOYEE" and columns are "NAME", "AGE", and we assume 2 rows, then the keys are formatted
+        as follows:
+        "EMPLOYEE_NAME1", "EMPLOYEE_AGE1", "EMPLOYEE_NAME2", "EMPLOYEE_AGE2"
+
+        Notice that the row number is appended to the column name. Where the row number is a positive integer starting
+        from 1 and can be any number of digits.
+
+        :param map_fields: a dictionary of map fields
+        :param table_name: the name of the table
+        :param column_names: a list of column names
+        :return: a list of dictionaries, each dictionary represents a row in the table
+        """
+        return self.map_util.transform_keyvalue_to_table(map_fields, table_name, column_names)
+
+    def transform_table_to_keyvalue(self, table: list[dict[str, MapUtil.MapValue]], table_name: str) -> dict[str, str]:
+        """
+        Helper Method to transform a table like datastructure to a dictionary of map fields
+
+        In Elo a table is faked by formatting the keys of the map fields. Example:
+        table_name is "EMPLOYEE" and columns are "NAME", "AGE", and we assume 2 rows, then the keys are formatted
+        as follows:
+        "EMPLOYEE_NAME1", "EMPLOYEE_AGE1", "EMPLOYEE_NAME2", "EMPLOYEE_AGE2"
+
+        Notice that the row number is appended to the column name. Where the row number is a positive integer starting
+        from 1 and can be any number of digits.
+
+        the result can directly be used in the function write_map_fields
+
+        :param table: a list of dictionaries, each dictionary represents a row in the table
+        :param table_name: the name of the table
+        :return: a dictionary of map fields
+        """
+        return self.map_util.transform_table_to_keyvalue(table, table_name)
 
     def upload_file(self, file_path: str, parent_id: str, filemask_id="0", filename="",
                     filename_objkey_id=FILENAME_OBJKEY_ID_DEFAULT,
@@ -256,7 +297,6 @@ class EloService:
         :return: The mask fields of the sord
         """
         return self.mask_util.get_mask_fields(sord_id)
-
 
     def remove(self, sord_id: str):
         """

--- a/eloservice/map_util.py
+++ b/eloservice/map_util.py
@@ -68,6 +68,7 @@ def too_large_for_string(fields: dict):
             return True
     return False
 
+
 class MapUtil:
     class ValueType:
         string = "string"
@@ -138,7 +139,7 @@ class MapUtil:
         body = BRequestIXServicePortIFCheckoutMap(
             domain_name=map_domain,
             id=sord_id,
-            key_names=keys, # if keys is None, all fields are read
+            key_names=keys,  # if keys is None, all fields are read
             lock_z=LockZ(LockC().bset_no)
         )
         res = ix_service_port_if_checkout_map.sync_detailed(client=self.elo_client, body=body)
@@ -190,3 +191,47 @@ class MapUtil:
             raise ValueError(f"Could not load file from stream {stream_url}")
         return res.content
 
+    def transform_keyvalue_to_table(self, map_fields: dict[str, MapValue], table_name: str, column_names: list[str]):
+        """
+        In Elo a table is faked by formatting the keys of the map fields. Example:
+        table_name is "EMPLOYEE" and columns are "NAME", "AGE", and we assume 2 rows, then the keys are formatted
+        as follows:
+        "EMPLOYEE_NAME1", "EMPLOYEE_AGE1", "EMPLOYEE_NAME2", "EMPLOYEE_AGE2"
+
+        Notice that the row number is appended to the column name. Where the row number is a positive integer starting
+        from 1 and can be any number of digits.
+
+        :param map_fields: a dictionary of map fields
+        :param table_name: the name of the table
+        :param column_names: a list of column names
+        :return: a list of dictionaries, each dictionary represents a row in the table
+        """
+        table = {}
+        for key, value in map_fields.items():
+            for column_name in column_names:
+                if key.startswith(table_name + "_" + column_name):
+                    name = key[len(table_name + "_" + column_name):]
+                    try:
+                        row_number = int(name)
+                    except ValueError:
+                        # happens when the column is repeated in the map fields e.g. SHAREHOLDER, SHAREHOLDERID
+                        continue
+                    row_number = int(name)
+                    row = table[row_number] if row_number in table else {}
+                    row[column_name] = value
+                    table[row_number] = row
+        return [row for row in table.values()]
+
+    def transform_table_to_keyvalue(self, table: list[dict], table_name: str):
+        """
+        The reverse of transform_keyvalue_to_table. Given a table, it transforms it to a dictionary of map fields.
+        :param table: a list of dictionaries, each dictionary represents a row in the table
+        :param table_name: the name of the table
+        :return: a dictionary of map fields
+        """
+        map_fields = {}
+        for row_number, row in enumerate(table, start=1):
+            for column_name, value in row.items():
+                key = f"{table_name}_{column_name}{row_number}"
+                map_fields[key] = value
+        return map_fields

--- a/eloservice/map_util.py
+++ b/eloservice/map_util.py
@@ -191,8 +191,11 @@ class MapUtil:
             raise ValueError(f"Could not load file from stream {stream_url}")
         return res.content
 
-    def transform_keyvalue_to_table(self, map_fields: dict[str, MapValue], table_name: str, column_names: list[str]):
+    def serialize_table(self, map_fields: dict[str, MapValue], table_name: str, column_names: list[str]) -> list[dict]:
         """
+        This method serializes, given the raw elo map fields, a table like format. The table is represented as a list
+        of dictionaries, where each dictionary represents a row in the table.
+
         In Elo a table is faked by formatting the keys of the map fields. Example:
         table_name is "EMPLOYEE" and columns are "NAME", "AGE", and we assume 2 rows, then the keys are formatted
         as follows:
@@ -222,9 +225,11 @@ class MapUtil:
                     table[row_number] = row
         return [table[row_number] for row_number in sorted(table.keys())]
 
-    def transform_table_to_keyvalue(self, table: list[dict], table_name: str):
+    def deserialize_table(self, table: list[dict], table_name: str):
         """
-        The reverse of transform_keyvalue_to_table. Given a table, it transforms it to a dictionary of map fields.
+        The reverse of serialize_table. Given a table, it transforms it to a dictionary of map fields.
+        Which can be directly written to elo via the method write_map_fields.
+
         :param table: a list of dictionaries, each dictionary represents a row in the table
         :param table_name: the name of the table
         :return: a dictionary of map fields

--- a/eloservice/map_util.py
+++ b/eloservice/map_util.py
@@ -220,7 +220,7 @@ class MapUtil:
                     row = table[row_number] if row_number in table else {}
                     row[column_name] = value
                     table[row_number] = row
-        return [row for row in table.values()]
+        return [table[row_number] for row_number in sorted(table.keys())]
 
     def transform_table_to_keyvalue(self, table: list[dict], table_name: str):
         """

--- a/test/test_map_util.py
+++ b/test/test_map_util.py
@@ -159,7 +159,7 @@ class TestService(unittest.TestCase):
         self.assertEqual(fields["testFileBlobPath"].blob_value, filebytes)
 
 
-    def test_transform_keyvalue_to_table(self):
+    def test_serialize_table(self):
         folderid = "115365"
         elo_connection, elo_client = self._login()
         service = elo_service.EloService(self.url, self.user, self.password)
@@ -167,11 +167,11 @@ class TestService(unittest.TestCase):
         map_fields = util.read_map_fields(sord_id=folderid)
         col_names = ["ASSIGNMENT", "ELOGUID","ELOOBJID","SHAREHOLDER","SHAREINPERCENT", "SHAREHOLDERID",]
         table_name = "SHARE_PARENT"
-        table = util.transform_keyvalue_to_table(map_fields, table_name=table_name, column_names=col_names)
+        table = util.serialize_table(map_fields, table_name=table_name, column_names=col_names)
         assert table is not None
         assert len(table) > 0
 
-    def test_transform_table_to_keyvalue(self):
+    def test_deserialize_table(self):
         folderid = "115365"
         elo_connection, elo_client = self._login()
         service = elo_service.EloService(self.url, self.user, self.password)
@@ -179,10 +179,10 @@ class TestService(unittest.TestCase):
         map_fields = util.read_map_fields(sord_id=folderid)
         col_names = ["ASSIGNMENT", "ELOGUID","ELOOBJID","SHAREHOLDER","SHAREINPERCENT", "SHAREHOLDERID",]
         table_name = "SHARE_PARENT"
-        table = util.transform_keyvalue_to_table(map_fields, table_name=table_name, column_names=col_names)
+        table = util.serialize_table(map_fields, table_name=table_name, column_names=col_names)
         assert table is not None
         assert len(table) > 0
-        key_values = util.transform_table_to_keyvalue(table, table_name=table_name)
+        key_values = util.deserialize_table(table, table_name=table_name)
         # assert that all keys from key_values are in map_fields and that the values are the same
         for key, value in key_values.items():
             assert key in map_fields

--- a/test/test_map_util.py
+++ b/test/test_map_util.py
@@ -8,9 +8,9 @@ from test import TEST_ROOT_DIR
 
 
 class TestService(unittest.TestCase):
-    url = "http://node2.treskon.net:6056/ix-Archive/rest"
-    user = "Administrator"
-    password = "bKKn1uNDY"
+    url = os.environ["TEST_ELO_IX_URL"]
+    user = os.environ["TEST_ELO_IX_USER"]
+    password = os.environ["TEST_ELO_IX_PASSWORD"]
 
     lorem = ("ÄÖÜLorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut "
              "labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et "
@@ -157,3 +157,34 @@ class TestService(unittest.TestCase):
         self.assertEqual(fields["testFileBlobPath"].mime_type, "image/png")
         self.assertEqual(fields["testFileBlobPath"].type, MapUtil.ValueType.blob_file)
         self.assertEqual(fields["testFileBlobPath"].blob_value, filebytes)
+
+
+    def test_transform_keyvalue_to_table(self):
+        folderid = "115365"
+        elo_connection, elo_client = self._login()
+        service = elo_service.EloService(self.url, self.user, self.password)
+        util = MapUtil(elo_client, elo_connection)
+        map_fields = util.read_map_fields(sord_id=folderid)
+        col_names = ["ASSIGNMENT", "ELOGUID","ELOOBJID","SHAREHOLDER","SHAREINPERCENT", "SHAREHOLDERID",]
+        table_name = "SHARE_PARENT"
+        table = util.transform_keyvalue_to_table(map_fields, table_name=table_name, column_names=col_names)
+        assert table is not None
+        assert len(table) > 0
+
+    def test_transform_table_to_keyvalue(self):
+        folderid = "115365"
+        elo_connection, elo_client = self._login()
+        service = elo_service.EloService(self.url, self.user, self.password)
+        util = MapUtil(elo_client, elo_connection)
+        map_fields = util.read_map_fields(sord_id=folderid)
+        col_names = ["ASSIGNMENT", "ELOGUID","ELOOBJID","SHAREHOLDER","SHAREINPERCENT", "SHAREHOLDERID",]
+        table_name = "SHARE_PARENT"
+        table = util.transform_keyvalue_to_table(map_fields, table_name=table_name, column_names=col_names)
+        assert table is not None
+        assert len(table) > 0
+        key_values = util.transform_table_to_keyvalue(table, table_name=table_name)
+        # assert that all keys from key_values are in map_fields and that the values are the same
+        for key, value in key_values.items():
+            assert key in map_fields
+            assert value.value == map_fields[key].value
+


### PR DESCRIPTION
  This method serializes, given the raw elo map fields, a table like format. The table is represented as a list
        of dictionaries, where each dictionary represents a row in the table.

        In Elo a table is faked by formatting the keys of the map fields. Example:
        table_name is "EMPLOYEE" and columns are "NAME", "AGE", and we assume 2 rows, then the keys are formatted
        as follows:
        "EMPLOYEE_NAME1", "EMPLOYEE_AGE1", "EMPLOYEE_NAME2", "EMPLOYEE_AGE2"

        Notice that the row number is appended to the column name. Where the row number is a positive integer starting
        from 1 and can be any number of digits.
