### PR TITLE
Maputils: serialize_table, deserialize_table remove table_name parameter

### DIFF
--- a/eloservice/elo_service.py
+++ b/eloservice/elo_service.py
@@ -156,29 +156,30 @@ class EloService:
         """
         return self.map_util.read_map_fields(sord_id=sord_id, keys=keys, map_domain=map_domain)
 
-    def serialize_map_fields_table(self, map_fields: dict[str, MapUtil.MapValue], table_name: str,
+    def serialize_map_fields_table(self, map_fields: dict[str, MapUtil.MapValue],
                                    column_names: list[str]):
         """
         Helper Method to serializes, given the raw elo map fields, a table like format. The table is represented as a list
         of dictionaries, where each dictionary represents a row in the table.
         All operations are done in memory and no ELO operations are performed.
 
-        In Elo a table inside the map fields, is faked by formatting the keys of the map fields. Example:
-        table_name is "EMPLOYEE" and columns are "NAME", "AGE", and we assume 2 rows, then the keys are formatted
-        as follows:
-        "EMPLOYEE_NAME1", "EMPLOYEE_AGE1", "EMPLOYEE_NAME2", "EMPLOYEE_AGE2"
+        In Elo a table is faked by formatting the keys of the map fields. Example:
+        We assume some employee table with columns are "EMPLOYEE_NAME", "AGE", and we assume 2 rows, then the keys are
+        formatted as follows:
+        "EMPLOYEE_NAME1", "AGE1", "EMPLOYEE_NAME2", "AGE2"
 
         Notice that the row number is appended to the column name. Where the row number is a positive integer starting
         from 1 and can be any number of digits.
+        Also Notice that there is no "table name" in the keys. The column names are arbitrary and do not need to contain
+        any information about the table.
 
-        :param map_fields: a dictionary of map fields
-        :param table_name: the name of the table
+        :param map_fields: a dictionary of map fields, comes from the function read_map_fields
         :param column_names: a list of column names
         :return: a list of dictionaries, each dictionary represents a row in the table
         """
-        return self.map_util.serialize_table(map_fields, table_name, column_names)
+        return self.map_util.serialize_table(map_fields, column_names)
 
-    def deserialize_map_fields_table(self, table: list[dict[str, MapUtil.MapValue]], table_name: str) -> dict[str, str]:
+    def deserialize_map_fields_table(self, table: list[dict[str, MapUtil.MapValue]]) -> dict[str, str]:
         """
         The reverse of serialize_map_fields_table.
         Given a table, it transforms it to a dictionary of map fields.
@@ -186,20 +187,21 @@ class EloService:
         All operations are done in memory and no ELO operations are performed.
 
         In Elo a table is faked by formatting the keys of the map fields. Example:
-        table_name is "EMPLOYEE" and columns are "NAME", "AGE", and we assume 2 rows, then the keys are formatted
-        as follows:
-        "EMPLOYEE_NAME1", "EMPLOYEE_AGE1", "EMPLOYEE_NAME2", "EMPLOYEE_AGE2"
+        We assume some employee table with columns are "EMPLOYEE_NAME", "AGE", and we assume 2 rows, then the keys are
+        formatted as follows:
+        "EMPLOYEE_NAME1", "AGE1", "EMPLOYEE_NAME2", "AGE2"
 
         Notice that the row number is appended to the column name. Where the row number is a positive integer starting
         from 1 and can be any number of digits.
+        Also Notice that there is no "table name" in the keys. The column names are arbitrary and do not need to contain
+        any information about the table.
 
         the result can directly be used in the function write_map_fields
 
         :param table: a list of dictionaries, each dictionary represents a row in the table
-        :param table_name: the name of the table
-        :return: a dictionary of map fields
+        :return: a dictionary of map fields, for the use in the function write_map_fields
         """
-        return self.map_util.deserialize_table(table, table_name)
+        return self.map_util.deserialize_table(table)
 
     def upload_file(self, file_path: str, parent_id: str, filemask_id="0", filename="",
                     filename_objkey_id=FILENAME_OBJKEY_ID_DEFAULT,

--- a/test/test_map_util.py
+++ b/test/test_map_util.py
@@ -145,7 +145,7 @@ class TestService(unittest.TestCase):
                                          separator="¶")
 
         filepath = TEST_ROOT_DIR + "/resources/testFile.png"
-        #read file path as bytes
+        # read file path as bytes
         filebytes = open(filepath, "rb").read()
 
         util.write_map_fields(sord_id=folderid,
@@ -158,16 +158,15 @@ class TestService(unittest.TestCase):
         self.assertEqual(fields["testFileBlobPath"].type, MapUtil.ValueType.blob_file)
         self.assertEqual(fields["testFileBlobPath"].blob_value, filebytes)
 
-
     def test_serialize_table(self):
         folderid = "115365"
         elo_connection, elo_client = self._login()
         service = elo_service.EloService(self.url, self.user, self.password)
         util = MapUtil(elo_client, elo_connection)
         map_fields = util.read_map_fields(sord_id=folderid)
-        col_names = ["ASSIGNMENT", "ELOGUID","ELOOBJID","SHAREHOLDER","SHAREINPERCENT", "SHAREHOLDERID",]
-        table_name = "SHARE_PARENT"
-        table = util.serialize_table(map_fields, table_name=table_name, column_names=col_names)
+        col_names = ["SHARE_PARENT_ASSIGNMENT", "SHARE_PARENT_ELOGUID", "SHARE_PARENT_ELOOBJID",
+                     "SHARE_PARENT_SHAREHOLDER", "SHARE_PARENT_SHAREINPERCENT", "SHARE_PARENT_SHAREHOLDERID", ]
+        table = util.serialize_table(map_fields, column_names=col_names)
         assert table is not None
         assert len(table) > 0
 
@@ -177,14 +176,13 @@ class TestService(unittest.TestCase):
         service = elo_service.EloService(self.url, self.user, self.password)
         util = MapUtil(elo_client, elo_connection)
         map_fields = util.read_map_fields(sord_id=folderid)
-        col_names = ["ASSIGNMENT", "ELOGUID","ELOOBJID","SHAREHOLDER","SHAREINPERCENT", "SHAREHOLDERID",]
-        table_name = "SHARE_PARENT"
-        table = util.serialize_table(map_fields, table_name=table_name, column_names=col_names)
+        col_names = ["SHARE_PARENT_ASSIGNMENT", "SHARE_PARENT_ELOGUID", "SHARE_PARENT_ELOOBJID",
+                     "SHARE_PARENT_SHAREHOLDER", "SHARE_PARENT_SHAREINPERCENT", "SHARE_PARENT_SHAREHOLDERID", ]
+        table = util.serialize_table(map_fields, column_names=col_names)
         assert table is not None
         assert len(table) > 0
-        key_values = util.deserialize_table(table, table_name=table_name)
+        key_values = util.deserialize_table(table)
         # assert that all keys from key_values are in map_fields and that the values are the same
         for key, value in key_values.items():
             assert key in map_fields
             assert value.value == map_fields[key].value
-


### PR DESCRIPTION
Assumption that the keys include a general table name was wrong. Apparently the keys can be completely arbitrary