### PR TITLE
Read and Write Map Fields: change the charset behaviour

### DIFF
--- a/eloservice/eloconstants.py
+++ b/eloservice/eloconstants.py
@@ -41,3 +41,19 @@ LOCK_Z_YES = LockZ("1")
 LOCK_Z_NO = LockZ("0")
 LOCK_Z_IF_FREE = LockZ("2")
 LOCK_Z_FORCE = LockZ("4")
+
+
+elo_text_mime_types = [
+    "text/",
+    "application/json",
+    "application/javascript",
+    "application/xml",
+    "application/x-www-form-urlencoded",
+    "application/xhtml+xml",
+    "application/html",
+    "application/xml",
+    "application/yaml",
+    "application/csv"
+    # not complete
+]
+

--- a/test/test_map_util.py
+++ b/test/test_map_util.py
@@ -12,7 +12,8 @@ class TestService(unittest.TestCase):
     user = os.environ["TEST_ELO_IX_USER"]
     password = os.environ["TEST_ELO_IX_PASSWORD"]
 
-    lorem = ("ÄÖÜLorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut "
+    lorem = ("€ÄÖÜ"
+             "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut "
              "labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et "
              "ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem "
              "ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et "
@@ -157,6 +158,29 @@ class TestService(unittest.TestCase):
         self.assertEqual(fields["testFileBlobPath"].mime_type, "image/png")
         self.assertEqual(fields["testFileBlobPath"].type, MapUtil.ValueType.blob_file)
         self.assertEqual(fields["testFileBlobPath"].blob_value, filebytes)
+
+    def test_read_map_fields_blob_string(self):
+        elo_connection, elo_client = self._login()
+        service = elo_service.EloService(self.url, self.user, self.password)
+        util = MapUtil(elo_client, elo_connection)
+
+        folderid = service.create_folder(path="¶Alpha AG¶IntegrationTests¶test",
+                                         separator="¶")
+
+        util.write_map_fields(sord_id=folderid, fields={"testBlob": "testBlob",
+                                                        "500CharBlob": self.lorem
+                                                        # bigger than ELO 255 char limit
+                                                        }
+
+                              , map_domain="Objekte",
+                              value_type=MapUtil.ValueType.blob_string)
+
+        map_fields = util.read_map_fields(sord_id=folderid, keys=["testBlob", "500CharBlob"])
+        self.assertEqual(map_fields["testBlob"].type, MapUtil.ValueType.blob_string)
+        self.assertEqual(map_fields["testBlob"].value, "testBlob")
+        self.assertEqual(map_fields["500CharBlob"].type, MapUtil.ValueType.blob_string)
+        self.assertEqual(map_fields["500CharBlob"].value, self.lorem)
+
 
     def test_serialize_table(self):
         folderid = "115365"


### PR DESCRIPTION
* Change the default charset to UTF-8;
* Reading: use the elo db column content_type to automatically convert a bytes array to a string with the given charset
